### PR TITLE
sqlite3: refactor: recursive traversal; cleanups 

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -6,8 +6,8 @@ package sqlite3
 
 // cellInfo holds information about an on-disk cell.
 type cellInfo struct {
-	Key          int64
-	RowID        int64
-	Payload      []byte
-	OverflowPage int32
+	LeftChildPage int32
+	RowID         *int64
+	Payload       []byte
+	OverflowPage  int32
 }

--- a/page.go
+++ b/page.go
@@ -22,9 +22,9 @@ The locking page
 
 const (
 	intKeyKind   PageKind = 0x01
-	zeroDataKind          = 0x02
-	leafDataKind          = 0x04
-	leafKind              = 0x08
+	zeroDataKind PageKind = 0x02
+	leafDataKind PageKind = 0x04
+	leafKind     PageKind = 0x08
 
 	BTreeInteriorIndexKind = zeroDataKind
 	BTreeInteriorTableKind = leafDataKind | intKeyKind


### PR DESCRIPTION
Major change:

- Add `visitRawInorder` and `visitRecordsInorder` to btree, which will
  load and traverse child pages recursively, and use them instead of
  iterating.

Smaller cleanups:

- Stash the db, not the dbheader in `btreeTable`, so we can decode
  child pages.
- Rename `load` to `decodeRecord`, and make it take just the payload
  bytes.
- Create `loadCell`, a wrapper around `parseCell` that first seeks to
  the right place. All callers used to do it themselves.
- Remove unused arg from `parseCell`, to emphasize that it only parses
  the cell at the current seek position.
- Remove unused struct type `btreeInteriorTable`.
- Rename `cellInfo.Key` to `cellInfo.LeftChildPage` -- as far as I can
  tell, no int32 "Key" is mentioned in the data format description --
  and don't put sizes in it.
- Make `RowID` in `cellInfo` a pointer, since it's optional, but may
  be zero.