### PR TITLE
sqlite3: s/uvarint/varint; fix <= 0x80 bug

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -114,7 +114,7 @@ func (btree *btreeTable) decodeRecord(payload []byte) (Record, error) {
 
 	// decode record
 	recbuf := payload[:]
-	rhdrsz, n := uvarint(recbuf)
+	rhdrsz, n := varint(recbuf)
 	if n <= 0 {
 		return rec, fmt.Errorf("sqlite3: error decoding record header (n=%d)", n)
 	}
@@ -122,7 +122,7 @@ func (btree *btreeTable) decodeRecord(payload []byte) (Record, error) {
 
 	rec.Header.Len = int(rhdrsz) - n
 	for ii := 0; ii < rec.Header.Len; {
-		v, n := uvarint(recbuf)
+		v, n := varint(recbuf)
 		// fmt.Printf("ii=%d nn=%d len=%d\n", ii, n, rec.Header.Len)
 		if n < 0 {
 			return rec, fmt.Errorf("sqlite3: error decoding record header type (n=%d)", n)
@@ -251,7 +251,7 @@ func (btree *btreeTable) parseCell() (cellInfo, error) {
 			return cell, fmt.Errorf("sqlite3: error decoding page number: %v", err)
 		}
 
-		rowid, nrow := btree.page.Uvarint()
+		rowid, nrow := btree.page.Varint()
 		if nrow <= 0 {
 			return cell, fmt.Errorf("sqlite3: error decoding rowid: n=%d", nrow)
 		}
@@ -267,12 +267,12 @@ func (btree *btreeTable) parseCell() (cellInfo, error) {
 	case BTreeLeafIndexKind:
 		panic("not implemented")
 	case BTreeLeafTableKind:
-		sz, nsz := btree.page.Uvarint()
+		sz, nsz := btree.page.Varint()
 		if nsz <= 0 {
 			return cell, fmt.Errorf("sqlite3: error decoding cell size: n=%d", nsz)
 		}
 
-		rowid, nrow := btree.page.Uvarint()
+		rowid, nrow := btree.page.Varint()
 		if nrow <= 0 {
 			return cell, fmt.Errorf("sqlite3: error decoding rowid: n=%d", nrow)
 		}

--- a/page.go
+++ b/page.go
@@ -147,8 +147,8 @@ func (p *page) Read(data []byte) (int, error) {
 	return n, nil
 }
 
-func (p *page) Uvarint() (uint64, int) {
-	v, n := uvarint(p.Bytes())
+func (p *page) Varint() (int64, int) {
+	v, n := varint(p.Bytes())
 	if n <= 0 {
 		return v, n
 	}

--- a/utils.go
+++ b/utils.go
@@ -27,19 +27,19 @@ func unmarshal(buf []byte, ptr interface{}) (int64, error) {
 	return int64(n), err
 }
 
-func uvarint(data []byte) (uint64, int) {
+func varint(data []byte) (int64, int) {
 	var val uint64
 	for i := 0; i < 8; i++ {
 		if i > len(data)-1 {
 			return 0, 0
 		}
 		val = (val << 7) | uint64(data[i]&0x7f)
-		if data[i] <= 0x80 {
-			return val, i + 1
+		if data[i] < 0x80 {
+			return int64(val), i + 1
 		}
 	}
 	if len(data) < 9 {
 		return 0, 0
 	}
-	return (val << 8) | uint64(data[8]), 9
+	return int64((val << 8) | uint64(data[8])), 9
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -6,10 +6,10 @@ package sqlite3
 
 import "testing"
 
-func TestUvarint(t *testing.T) {
+func TestVarint(t *testing.T) {
 	testdata := []struct {
 		in      []byte
-		valWant uint64
+		valWant int64
 		nWant   int
 	}{
 		{[]byte{0x7f}, 0x7f, 1},
@@ -17,14 +17,15 @@ func TestUvarint(t *testing.T) {
 		{[]byte{0x81}, 0x0, 0},
 		{[]byte{0x81, 0x1}, 0x81, 2},
 		{[]byte{0x83, 0x60}, 0x1e0, 2},
-		{[]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, 0xffffffffffffffff, 9},
+		{[]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, -1, 9},
+		{[]byte{0x97, 0xa0, 0x80, 0xdf, 0xe9, 0xda, 0xf3, 0x02}, 13088612140104066, 8},
 	}
 
 	for _, tt := range testdata {
-		valGot, nGot := uvarint(tt.in)
+		valGot, nGot := varint(tt.in)
 
 		if tt.valWant != valGot || tt.nWant != nGot {
-			t.Errorf("want uvarint(%v) = (%d, %d); got (%d, %d)", tt.in, tt.valWant, tt.nWant, valGot, nGot)
+			t.Errorf("want varint(%v) = (%d, %d); got (%d, %d)", tt.in, tt.valWant, tt.nWant, valGot, nGot)
 		}
 	}
 }


### PR DESCRIPTION
- Fix bug in varint decoding where comparison was `<= 0x80` instead of
  `< 0x80`. My, that took some digging.
- Change `uvarint` to `varint` everywhere: sqlite doesn't have
  "unsigned varints".