### PR TITLE
Abstract database interface slightly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,5 +9,6 @@
 # Please keep the list sorted.
 
 Adam Shannon <adamkshannon@gmail.com>
+Andre Renaud <andre@ignavus.net>
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>
 Zellyn Hunter <zellyn@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,5 +16,6 @@
 # Please keep the list sorted.
 
 Adam Shannon <adamkshannon@gmail.com>
+Andre Renaud <andre@ignavus.net>
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>
 Zellyn Hunter <zellyn@gmail.com>


### PR DESCRIPTION
At the moment we require the sqlite3 database to be in an on-disk
file. We can abstract this slightly to allow an interface-based
database to be opened